### PR TITLE
ci: store HTML coverage report

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,28 +12,47 @@ jobs:
     runs-on: ubuntu-latest
     #container:
     #  image: centos8 
-    
+
     steps:
-    - uses: dtolnay/rust-toolchain@1.69.0
     - uses: actions/checkout@v3
-    - name: Preparing
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: 1.69.0
+        override: true
+    - name: Installing dependency packages
       run: sudo apt update && sudo apt install -y libxen-dev protobuf-compiler
 
     - name: Build
       run: cargo build --verbose
 
-    - name: Install cargo-llvm-cov
-      uses: taiki-e/install-action@cargo-llvm-cov
-    
-    - name: Generate code coverage
-      run: cargo llvm-cov --all-features --workspace --codecov --output-path cov.json
-    
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions-rs/toolchain@v1
       with:
-        token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos
-        files: cov.json
-        fail_ci_if_error: true
-    
+        toolchain: nightly
+        override: true
+    - name: Installing dependency packages
+      run: sudo apt update && sudo apt install -y libxen-dev protobuf-compiler
+
     - name: Run tests
-      run: cargo test --verbose
+      run: |
+        cargo clean
+        cargo test --verbose
+      env:
+        CARGO_INCREMENTAL: '0'
+        RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests'
+        RUSTDOCFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests'
+
+    - name: Install grcov
+      run: cargo install grcov
+    - name: Test coverage report
+      run: grcov . -s . --binary-path ./target/debug/ -t html --branch --ignore-not-existing -o ./target/debug/coverage/
+
+    - name: Upload test coverage report
+      uses: actions/upload-artifact@v3
+      with:
+        name: coverage-html
+        path: ./target/debug/coverage/


### PR DESCRIPTION
- use grcov over llvmcov for simplicity and ability to reuse results (?)
- upload as artifact and not to codecov.io
- split test and build into separate jobs, so failed tests do not appear as failing the build, and allowing to use a nightly toolchain for tests while still building with stable toolchain
- use more standard actions-rs/toolchain to support nightly builds